### PR TITLE
Minimal changes to compile on windows.

### DIFF
--- a/getlogin.go
+++ b/getlogin.go
@@ -1,5 +1,7 @@
 // Package getlogin provides functionality similar to libc's getlogin(3).
 
+// +build !windows
+
 // Similar to getlogin(3), this package should NOT be used for any security related checks.
 package getlogin
 

--- a/getlogin_windows.go
+++ b/getlogin_windows.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package getlogin
+
+import (
+	"errors"
+	"os"
+	"os/user"
+)
+
+// Returns the name of the user from the environment.
+// This function can be easily fooled and should NOT be used for any security related purposes.
+func GetLogin() string {
+	return LoginFromEnv()
+}
+
+// Not supported on windows.
+func UserFromStdin() (*user.User, error) {
+	return nil, errors.New("not supported on windows")
+}
+
+// Returns username from environment variable USERNAME.
+// This function should NOT be used for any security related purposes.
+func LoginFromEnv() string {
+	return os.Getenv("USERNAME")
+}

--- a/tty.go
+++ b/tty.go
@@ -1,4 +1,4 @@
-// +build !solaris
+// +build !solaris,!windows
 
 package getlogin
 


### PR DESCRIPTION
Only support getting user name from environment variable USERNAME. I
put in a stub implementation of UserFromStdin() that always returns an
error to keep parity w/ package API.